### PR TITLE
fix(installer): config now load correctly

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -64,8 +64,11 @@ function packer_setup {
 	# install all new plugins
 	try lvim --headless \
 		-c "autocmd User PackerComplete quitall" \
+		-c "PackerInstall"
+
+	# compile
+	try lvim --headless \
 		-c "autocmd User PackerCompileDone quitall" \
-		-c "PackerInstall" \
 		-c "PackerCompile"
 
 	echo "Packer setup complete"


### PR DESCRIPTION
- `PackerSync` and `PackerCompile` must be in two separated `lvim` commands.